### PR TITLE
Mac testing github action

### DIFF
--- a/.github/workflows/mac-pytest.yml
+++ b/.github/workflows/mac-pytest.yml
@@ -1,0 +1,45 @@
+name: Mac - PyTest
+
+on: [push]
+# Update to only push on main branch push
+
+jobs:
+  mac:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+      - name: Homebrew install reqs
+        run: |
+          brew update
+          brew install gdal spatialindex
+          brew upgrade
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      # Install GDAL
+      # Install python dependencies
+      - name: Install python dependencies
+        run: |
+          pip install -r requirements.txt
+
+      # Install testing dependencies
+      - name: Install testing dependencies
+        run: |
+          pip install -r requirements-test.txt
+
+      # Run pytest
+      - name: Test with Pytest
+        run: |
+          PYTHONPATH=. pytest tests/ -v --cov lmpy --cov-report term-missing

--- a/.github/workflows/mac_pytest.yml
+++ b/.github/workflows/mac_pytest.yml
@@ -1,7 +1,12 @@
 name: Mac - PyTest
 
-on: [push]
-# Update to only push on main branch push
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   mac:
@@ -15,7 +20,7 @@ jobs:
           brew update
           brew install gdal spatialindex
           brew upgrade
-      # Checks out a copy of your repository on the ubuntu-latest machine
+      # Checks out a copy of your repository
       - name: Checkout code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Perform mac testing on pushes and pull requests for the main branch.  These tests take much longer than ubuntu image tests and seem to have more restrictions, thus, setting to only be for main branch.  Take out that restriction if it is determined that we always want to perform mac tests.

Ubuntu machine tests always happen