### PR TITLE
Add additional matrix data wranglers

### DIFF
--- a/lmpy/data_wrangling/matrix/match_tree_wrangler.py
+++ b/lmpy/data_wrangling/matrix/match_tree_wrangler.py
@@ -1,0 +1,65 @@
+"""Module containing data wranglers for matching a matrix to a tree."""
+from lmpy.tree import TreeWrapper
+
+from lmpy.data_wrangling.matrix.base import _MatrixDataWrangler
+
+
+# .....................................................................................
+class MatchTreeMatrixWrangler(_MatrixDataWrangler):
+    """Subset and reorder a matrix to match a tree."""
+    name = 'MatchTreeMatrixWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        tree,
+        species_axis,
+        **params
+    ):
+        """Constructor for MatchTreeMatrixWrangler class.
+
+        Args:
+            tree (TreeWrapper or str): A tree object or file path to a tree.
+            species_axis (int): The matrix axis with species names to match.
+            **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
+        """
+        _MatrixDataWrangler.__init__(self, **params)
+
+        if isinstance(tree, str):
+            tree = TreeWrapper.from_filename(tree)
+        self.tree = tree
+        self.species_axis = species_axis
+        self.report['changes'] = {}
+
+    # .......................
+    def wrangle_matrix(self, matrix):
+        """Wrangle a matrix.
+
+        Args:
+            matrix (Matrix): A matrix to wrangle.
+
+        Returns:
+            Matrix: The matrix subset to tree tip names.
+        """
+        slices = []
+        for axis in range(matrix.ndim):
+            if axis == self.species_axis:
+                axis_slice = []
+                axis_headers = matrix.get_headers(axis=str(axis))
+
+                for taxon in self.tree.taxon_namespace:
+                    if taxon.label in axis_headers:
+                        axis_slice.append(axis_headers.index(taxon.label))
+
+                if str(axis) not in self.report['changes'].keys():
+                    self.report['changes'][str(axis)] = {'purged': 0}
+                self.report[
+                    'changes'
+                ][str(axis)]['purged'] += len(axis_headers) - len(axis_slice)
+            else:
+                axis_slice = list(range(matrix.shape[axis]))
+
+            slices.append(axis_slice)
+
+        return matrix.slice(*slices)

--- a/lmpy/data_wrangling/matrix/purge_empty_slices_wrangler.py
+++ b/lmpy/data_wrangling/matrix/purge_empty_slices_wrangler.py
@@ -1,0 +1,58 @@
+"""Module containing occurrence data wranglers for purging empty matrix slices."""
+import numpy as np
+
+from lmpy.data_wrangling.matrix.base import _MatrixDataWrangler
+
+
+# .....................................................................................
+class PurgeEmptySlicesWrangler(_MatrixDataWrangler):
+    """Removes empty slices (rows, columns, other) from a matrix."""
+    name = 'PurgeEmptySlicesWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        purge_axes=None,
+        **params
+    ):
+        """Constructor for PurgeEmptySlicesWrangler class.
+
+        Args:
+            purge_axes (None, int, or list of int): Matrix axes to be processed.
+            **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
+        """
+        _MatrixDataWrangler.__init__(self, **params)
+        # Make purge_axes a list if it is not None
+        if isinstance(purge_axes, int):
+            purge_axes = [purge_axes]
+        self.purge_axes = purge_axes
+        self.report['changes'] = {}
+
+    # .......................
+    def wrangle_matrix(self, matrix):
+        """Wrangle a matrix.
+
+        Args:
+            matrix (Matrix): A matrix to wrangle.
+
+        Returns:
+            Matrix: The matrix with empty slices purged.
+        """
+        slices = []
+        for axis in range(matrix.ndim):
+            if self.purge_axes is None or axis in self.purge_axes:
+                sum_axes = list(range(matrix.ndim))
+                sum_axes.remove(axis)
+                axis_slice = np.where(matrix.sum(axis=tuple(sum_axes)) != 0)[0]
+
+                if str(axis) not in self.report['changes'].keys():
+                    self.report['changes'][str(axis)] = {'purged': 0}
+                self.report['changes'][str(axis)]['purged'] += len(
+                    np.where(matrix.sum(axis=tuple(sum_axes)) == 0)[0]
+                )
+            else:
+                axis_slice = list(range(matrix.shape[axis]))
+            slices.append(axis_slice)
+
+        return matrix.slice(*slices)

--- a/lmpy/data_wrangling/matrix/subset_reorder_slices_wrangler.py
+++ b/lmpy/data_wrangling/matrix/subset_reorder_slices_wrangler.py
@@ -1,0 +1,59 @@
+"""Module containing data wranglers for subsetting and reordering matrix slices."""
+from lmpy.data_wrangling.matrix.base import _MatrixDataWrangler
+
+
+# .....................................................................................
+class SubsetReorderSlicesWrangler(_MatrixDataWrangler):
+    """Subsets and / or reorders matrix slices."""
+    name = 'SubsetReorderSlicesWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        axes,
+        **params
+    ):
+        """Constructor for PurgeEmptySlicesWrangler class.
+
+        Args:
+            axes (dict): A dictionary of axis keys (int or str of int) and list of
+                values of those headers to keep.
+            **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
+        """
+        _MatrixDataWrangler.__init__(self, **params)
+        # Convert axis keys to integers
+        self.slice_axes = {int(k): axes[k] for k in axes.keys()}
+        self.report['changes'] = {}
+
+    # .......................
+    def wrangle_matrix(self, matrix):
+        """Wrangle a matrix.
+
+        Args:
+            matrix (Matrix): A matrix to wrangle.
+
+        Returns:
+            Matrix: The matrix with empty slices purged.
+        """
+        slices = []
+        for axis in range(matrix.ndim):
+            if axis in self.slice_axes.keys():
+                axis_slice = []
+                axis_headers = matrix.get_headers(axis=str(axis))
+                for idx in self.slice_axes[axis]:
+                    # If the header is in the axis headers, append the index
+                    if idx in axis_headers:
+                        axis_slice.append(axis_headers.index(idx))
+
+                if str(axis) not in self.report['changes'].keys():
+                    self.report['changes'][str(axis)] = {'purged': 0}
+                self.report[
+                    'changes'
+                ][str(axis)]['purged'] += len(axis_headers) - len(axis_slice)
+            else:
+                axis_slice = list(range(matrix.shape[axis]))
+
+            slices.append(axis_slice)
+
+        return matrix.slice(*slices)

--- a/tests/test_data_wrangling/test_matrix/test_match_tree_wrangler.py
+++ b/tests/test_data_wrangling/test_matrix/test_match_tree_wrangler.py
@@ -1,0 +1,107 @@
+"""Test the match_tree_wrangler module."""
+from copy import deepcopy
+
+import numpy as np
+
+from lmpy.matrix import Matrix
+from lmpy.data_wrangling.matrix.match_tree_wrangler import MatchTreeMatrixWrangler
+
+from tests.data_simulator import generate_tree
+
+
+# .....................................................................................
+def test_match_tree_wrangler_from_filename(generate_temp_filename):
+    """Test subsetting and reordering matrix slices to match a tree filename.
+
+    Args:
+        generate_temp_filename (pytest.fixture): A fixture for generating filenames.
+    """
+    # All species
+    all_species = [f'Species {i}' for i in range(100)]
+    # Shuffle species for selection in matrix
+    np.random.shuffle(all_species)
+    matrix_species = all_species[:np.random.randint(51, 75)]
+    # Shuffle species for selection in tree
+    np.random.shuffle(all_species)
+    tree_species = all_species[:np.random.randint(51, 75)]
+
+    num_cols = 100
+
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((len(matrix_species), num_cols)),
+        headers={
+            '1': [f'Col {i}' for i in range(num_cols)],
+            '0': matrix_species
+        }
+    )
+
+    # Generate test tree
+    tree = generate_tree(deepcopy(tree_species))
+    tree_filename = generate_temp_filename(suffix='.tre')
+    tree.write(path=tree_filename, schema='newick')
+
+    # Wrangle
+    wrangler = MatchTreeMatrixWrangler(tree_filename, 0)
+    wrangled_matrix = wrangler.wrangle_matrix(deepcopy(test_matrix))
+
+    # Check that number of rows is less than or equal to len(matrix_species)
+    assert wrangled_matrix.shape[0] <= len(matrix_species)
+
+    # Make sure all headers are in matrix and tree species
+    for sp in wrangled_matrix.get_row_headers():
+        assert sp in matrix_species
+        assert sp in tree_species
+
+    # Check that we purged between zero and len(matrix_species) - 1
+    report = wrangler.get_report()
+    assert report['changes']['0']['purged'] >= 0
+    # The test should ensure that we have at least one common species
+    assert report['changes']['0']['purged'] <= len(matrix_species) - 1
+    assert list(report['changes'].keys()) == ['0']
+
+
+# .....................................................................................
+def test_match_tree_wrangler_from_tree():
+    """Test subsetting and reordering matrix slices to match a tree object."""
+    # All species
+    all_species = [f'Species {i}' for i in range(100)]
+    # Shuffle species for selection in matrix
+    np.random.shuffle(all_species)
+    matrix_species = all_species[:np.random.randint(51, 75)]
+    # Shuffle species for selection in tree
+    np.random.shuffle(all_species)
+    tree_species = all_species[:np.random.randint(51, 75)]
+
+    num_rows = 100
+
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((num_rows, len(matrix_species))),
+        headers={
+            '0': [f'Row {i}' for i in range(num_rows)],
+            '1': matrix_species
+        }
+    )
+
+    # Generate test tree
+    tree = generate_tree(deepcopy(tree_species))
+
+    # Wrangle
+    wrangler = MatchTreeMatrixWrangler(tree, 1)
+    wrangled_matrix = wrangler.wrangle_matrix(deepcopy(test_matrix))
+
+    # Check that number of columns is less than or equal to len(matrix_species)
+    assert wrangled_matrix.shape[1] <= len(matrix_species)
+
+    # Make sure all headers are in matrix and tree species
+    for sp in wrangled_matrix.get_column_headers():
+        assert sp in matrix_species
+        assert sp in tree_species
+
+    # Check that we purged between zero and len(matrix_species) - 1
+    report = wrangler.get_report()
+    assert report['changes']['1']['purged'] >= 0
+    # The test should ensure that we have at least one common species
+    assert report['changes']['1']['purged'] <= len(matrix_species) - 1
+    assert list(report['changes'].keys()) == ['1']

--- a/tests/test_data_wrangling/test_matrix/test_purge_empty_slices_wrangler.py
+++ b/tests/test_data_wrangling/test_matrix/test_purge_empty_slices_wrangler.py
@@ -1,0 +1,110 @@
+"""Test the accepted_name_wrangler module."""
+from copy import deepcopy
+
+import numpy as np
+
+from lmpy.matrix import Matrix
+from lmpy.data_wrangling.matrix.purge_empty_slices_wrangler import (
+    PurgeEmptySlicesWrangler,
+)
+
+
+# .....................................................................................
+def test_purge_empty_slices_wrangler_2d():
+    """Test purging a matrix with empty rows and columns."""
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((5, 7)),
+        headers={
+            '0': [f'Row {i}' for i in range(5)],
+            '1': [f'Species {j}' for j in range(7)]
+        }
+    )
+    test_matrix[1] = 0
+    test_matrix[3] = 0
+    test_matrix[:, 4] = 0
+    test_matrix[:, 0] = 0
+
+    # Purge rows
+    wrangler_1 = PurgeEmptySlicesWrangler(purge_axes=0)
+    wrangled_matrix_1 = wrangler_1.wrangle_matrix(deepcopy(test_matrix))
+    # Assert that the rows were removed but nothing else
+    assert wrangled_matrix_1.shape == (3, 7)
+    report_1 = wrangler_1.get_report()
+    assert report_1['changes']['0']['purged'] == 2
+    assert list(report_1['changes'].keys()) == ['0']
+
+    # Purge columns
+    wrangler_2 = PurgeEmptySlicesWrangler(purge_axes=[1])
+    wrangled_matrix_2 = wrangler_2.wrangle_matrix(deepcopy(test_matrix))
+    # Assert that the columns were removed but nothing else
+    assert wrangled_matrix_2.shape == (5, 5)
+    report_2 = wrangler_2.get_report()
+    assert report_2['changes']['1']['purged'] == 2
+    assert list(report_2['changes'].keys()) == ['1']
+
+    # Purge both
+    wrangler_3 = PurgeEmptySlicesWrangler()
+    wrangled_matrix_3 = wrangler_3.wrangle_matrix(deepcopy(test_matrix))
+    # Assert that the rows and columns were removed but nothing else
+    assert wrangled_matrix_3.shape == (3, 5)
+    report_3 = wrangler_3.get_report()
+    assert report_3['changes']['0']['purged'] == 2
+    assert report_3['changes']['1']['purged'] == 2
+    assert list(report_3['changes'].keys()) == ['0', '1']
+
+
+# .....................................................................................
+def test_purge_empty_slices_wrangler_3d():
+    """Test purging a matrix with more than two dimensions."""
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((5, 7, 4)),
+        headers={
+            '0': [f'Row {i}' for i in range(5)],
+            '1': [f'Species {j}' for j in range(7)],
+            '2': [f'Plane {k}' for k in range(4)]
+        }
+    )
+    test_matrix[1] = 0
+    test_matrix[3] = 0
+    test_matrix[:, 4] = 0
+    test_matrix[:, 0] = 0
+    test_matrix[:, :, 2] = 0
+
+    # Purge
+    wrangler = PurgeEmptySlicesWrangler()
+    wrangled_matrix = wrangler.wrangle_matrix(deepcopy(test_matrix))
+
+    # We should purge 2 row, 2 columns, 1 plane
+    assert wrangled_matrix.shape == (3, 5, 3)
+
+    report = wrangler.get_report()
+    assert report['changes']['0']['purged'] == 2
+    assert report['changes']['1']['purged'] == 2
+    assert report['changes']['2']['purged'] == 1
+    assert list(report['changes'].keys()) == ['0', '1', '2']
+
+
+# .....................................................................................
+def test_purge_empty_slices_wrangler_not_empty():
+    """Test purging a matrix that has no empty slices."""
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((5, 7)),
+        headers={
+            '0': [f'Row {i}' for i in range(5)],
+            '1': [f'Species {j}' for j in range(7)]
+        }
+    )
+
+    # Attempt to purge
+    wrangler = PurgeEmptySlicesWrangler()
+    wrangled_matrix = wrangler.wrangle_matrix(deepcopy(test_matrix))
+
+    # No empty rows or columns so shape should be the same and no changes
+    assert wrangled_matrix.shape == (5, 7)
+    report = wrangler.get_report()
+    assert len(report['changes'].keys()) == 2
+    assert report['changes']['0']['purged'] == 0
+    assert report['changes']['1']['purged'] == 0

--- a/tests/test_data_wrangling/test_matrix/test_subset_reorder_slices_wrangler.py
+++ b/tests/test_data_wrangling/test_matrix/test_subset_reorder_slices_wrangler.py
@@ -1,0 +1,76 @@
+"""Test the accepted_name_wrangler module."""
+from copy import deepcopy
+
+import numpy as np
+
+from lmpy.matrix import Matrix
+from lmpy.data_wrangling.matrix.subset_reorder_slices_wrangler import (
+    SubsetReorderSlicesWrangler,
+)
+
+
+# .....................................................................................
+def test_subset_reorder_slices_wrangler():
+    """Test subsetting and reordering matrix slices."""
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((5, 7)),
+        headers={
+            '0': [f'Row {i}' for i in range(5)],
+            '1': [f'Species {j}' for j in range(7)]
+        }
+    )
+
+    # Subset rows
+    wrangler_1 = SubsetReorderSlicesWrangler({'0': ['Row 3', 'Row 2', 'Row 4']})
+    wrangled_matrix_1 = wrangler_1.wrangle_matrix(deepcopy(test_matrix))
+
+    # Assert that the rows were removed but nothing else
+    assert wrangled_matrix_1.shape == (3, 7)
+    report_1 = wrangler_1.get_report()
+    assert report_1['changes']['0']['purged'] == 2
+    assert list(report_1['changes'].keys()) == ['0']
+    assert wrangled_matrix_1.get_row_headers() == ['Row 3', 'Row 2', 'Row 4']
+    assert wrangled_matrix_1.get_column_headers() == [f'Species {j}' for j in range(7)]
+
+    # Subset columns and include one that isn't present
+    wrangler_2 = SubsetReorderSlicesWrangler(
+        {
+            '1': ['Species 0', 'Species 3', 'Species 5', 'Species 2', 'Species 99999']
+        }
+    )
+    wrangled_matrix_2 = wrangler_2.wrangle_matrix(deepcopy(test_matrix))
+    # Assert that the columns were removed but nothing else
+    assert wrangled_matrix_2.shape == (5, 4)
+    report_2 = wrangler_2.get_report()
+    assert report_2['changes']['1']['purged'] == 3
+    assert list(report_2['changes'].keys()) == ['1']
+    assert wrangled_matrix_2.get_row_headers() == [f'Row {i}' for i in range(5)]
+    assert wrangled_matrix_2.get_column_headers() == [
+        'Species 0',
+        'Species 3',
+        'Species 5',
+        'Species 2',
+    ]
+
+    # Purge both
+    wrangler_3 = SubsetReorderSlicesWrangler(
+        {
+            '0': ['Row 3', 'Row 2', 'Row 4'],
+            '1': ['Species 0', 'Species 3', 'Species 5', 'Species 2', 'Species 99999']
+        }
+    )
+    wrangled_matrix_3 = wrangler_3.wrangle_matrix(deepcopy(test_matrix))
+    # Assert that the rows and columns were removed but nothing else
+    assert wrangled_matrix_3.shape == (3, 4)
+    report_3 = wrangler_3.get_report()
+    assert report_3['changes']['0']['purged'] == 2
+    assert report_3['changes']['1']['purged'] == 3
+    assert list(report_3['changes'].keys()) == ['0', '1']
+    assert wrangled_matrix_3.get_row_headers() == ['Row 3', 'Row 2', 'Row 4']
+    assert wrangled_matrix_3.get_column_headers() == [
+        'Species 0',
+        'Species 3',
+        'Species 5',
+        'Species 2',
+    ]


### PR DESCRIPTION
Add matrix data wranglers for purging empty matrix slices and for subsetting by keeping specific slices indicated by headers

## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Add matrix data wranglers for common operations

## Link(s) to issue

#204 #203 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Sample Data
- [ ] Build Sphinx Documentation

