### PR TITLE
Add tree subsetting and matching wranglers

### DIFF
--- a/lmpy/data_wrangling/tree/match_matrix_wrangler.py
+++ b/lmpy/data_wrangling/tree/match_matrix_wrangler.py
@@ -1,0 +1,47 @@
+"""Module containing data wranglers for subsetting a tree to match a matrix."""
+from lmpy.matrix import Matrix
+
+from lmpy.data_wrangling.tree.base import _TreeDataWrangler
+
+
+# .....................................................................................
+class MatchMatrixTreeWrangler(_TreeDataWrangler):
+    """Subsets a tree to match the species in the matrix."""
+    name = 'MatchMatrixTreeWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        matrix,
+        species_axis,
+        **params
+    ):
+        """Constructor for SubsetTreeWrangler class.
+
+        Args:
+            matrix (Matrix): A matrix to get taxon names to match.
+            species_axis (int): The matrix axis with taxon names.
+            **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
+        """
+        _TreeDataWrangler.__init__(self, **params)
+        if isinstance(matrix, str):
+            matrix = Matrix.load(matrix)
+        self.keep_taxon_names = matrix.get_headers(axis=str(species_axis))
+        self.report['purged'] = 0
+
+    # .......................
+    def wrangle_tree(self, tree):
+        """Wrangle a tree.
+
+        Args:
+            tree (TreeWrapper): A tree to wrangle.
+
+        Returns:
+            TreeWrapper: The subsetted tree.
+        """
+        original_taxa_count = len(tree.taxon_namespace)
+        tree.retain_taxa_with_labels(self.keep_taxon_names)
+        tree.purge_taxon_namespace()
+        self.report['purged'] += original_taxa_count - len(tree.taxon_namespace)
+        return tree

--- a/lmpy/data_wrangling/tree/subset_tree_wrangler.py
+++ b/lmpy/data_wrangling/tree/subset_tree_wrangler.py
@@ -1,0 +1,41 @@
+"""Module containing data wranglers for subsetting a tree."""
+from lmpy.data_wrangling.tree.base import _TreeDataWrangler
+
+
+# .....................................................................................
+class SubsetTreeWrangler(_TreeDataWrangler):
+    """Subsets a tree."""
+    name = 'SubsetTreeWrangler'
+    version = '1.0'
+
+    # .......................
+    def __init__(
+        self,
+        keep_taxa,
+        **params
+    ):
+        """Constructor for SubsetTreeWrangler class.
+
+        Args:
+            keep_taxa (list of str): A list of taxon names to keep.
+            **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
+        """
+        _TreeDataWrangler.__init__(self, **params)
+        self.keep_taxon_names = keep_taxa
+        self.report['purged'] = 0
+
+    # .......................
+    def wrangle_tree(self, tree):
+        """Wrangle a tree.
+
+        Args:
+            tree (TreeWrapper): A tree to wrangle.
+
+        Returns:
+            TreeWrapper: The subsetted tree.
+        """
+        original_taxa_count = len(tree.taxon_namespace)
+        tree.retain_taxa_with_labels(self.keep_taxon_names)
+        tree.purge_taxon_namespace()
+        self.report['purged'] += original_taxa_count - len(tree.taxon_namespace)
+        return tree

--- a/tests/test_data_wrangling/test_tree/test_match_matrix_wrangler.py
+++ b/tests/test_data_wrangling/test_tree/test_match_matrix_wrangler.py
@@ -1,0 +1,105 @@
+"""Test the match_tree_wrangler module."""
+from copy import deepcopy
+
+import numpy as np
+
+from lmpy.matrix import Matrix
+from lmpy.data_wrangling.tree.match_matrix_wrangler import MatchMatrixTreeWrangler
+
+from tests.data_simulator import generate_tree
+
+
+# .....................................................................................
+def test_match_matrix_wrangler_from_filename(generate_temp_filename):
+    """Test subsetting and reordering matrix slices to match a tree filename.
+
+    Args:
+        generate_temp_filename (pytest.fixture): A fixture for generating filenames.
+    """
+    # All species
+    all_species = [f'Species {i}' for i in range(100)]
+    # Shuffle species for selection in matrix
+    np.random.shuffle(all_species)
+    matrix_species = all_species[:np.random.randint(51, 75)]
+    # Shuffle species for selection in tree
+    np.random.shuffle(all_species)
+    tree_species = all_species[:np.random.randint(51, 75)]
+
+    num_cols = 100
+
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((len(matrix_species), num_cols)),
+        headers={
+            '1': [f'Col {i}' for i in range(num_cols)],
+            '0': matrix_species
+        }
+    )
+    matrix_filename = generate_temp_filename(suffix='.lmm')
+    test_matrix.write(matrix_filename)
+
+    # Generate test tree
+    test_tree = generate_tree(deepcopy(tree_species))
+
+    # Wrangle
+    wrangler = MatchMatrixTreeWrangler(matrix_filename, 0)
+    wrangled_tree = wrangler.wrangle_tree(deepcopy(test_tree))
+
+    # Check that the number of taxa is less than or equal to len(tree_species)
+    assert len(wrangled_tree.taxon_namespace) <= len(tree_species)
+
+    # Make sure all taxa are in matrix and tree species
+    for taxon in wrangled_tree.taxon_namespace:
+        assert taxon.label in matrix_species
+        assert taxon.label in tree_species
+
+    # Check that we purged between zero and len(tree_species) - 1
+    report = wrangler.get_report()
+    assert report['purged'] >= 0
+    # The test should ensure that we have at least one common species
+    assert report['purged'] <= len(tree_species) - 1
+
+
+# .....................................................................................
+def test_match_matrix_wrangler_from_matrix():
+    """Test subsetting and reordering matrix slices to match a tree object."""
+    # All species
+    all_species = [f'Species {i}' for i in range(100)]
+    # Shuffle species for selection in matrix
+    np.random.shuffle(all_species)
+    matrix_species = all_species[:np.random.randint(51, 75)]
+    # Shuffle species for selection in tree
+    np.random.shuffle(all_species)
+    tree_species = all_species[:np.random.randint(51, 75)]
+
+    num_rows = 100
+
+    # Create test matrix
+    test_matrix = Matrix(
+        np.ones((num_rows, len(matrix_species))),
+        headers={
+            '0': [f'Row {i}' for i in range(num_rows)],
+            '1': matrix_species
+        }
+    )
+
+    # Generate test tree
+    test_tree = generate_tree(deepcopy(tree_species))
+
+    # Wrangle
+    wrangler = MatchMatrixTreeWrangler(test_matrix, 1)
+    wrangled_tree = wrangler.wrangle_tree(deepcopy(test_tree))
+
+    # Check that the number of taxa is less than or equal to len(tree_species)
+    assert len(wrangled_tree.taxon_namespace) <= len(tree_species)
+
+    # Make sure all taxa are in matrix and tree species
+    for taxon in wrangled_tree.taxon_namespace:
+        assert taxon.label in matrix_species
+        assert taxon.label in tree_species
+
+    # Check that we purged between zero and len(tree_species) - 1
+    report = wrangler.get_report()
+    assert report['purged'] >= 0
+    # The test should ensure that we have at least one common species
+    assert report['purged'] <= len(tree_species) - 1

--- a/tests/test_data_wrangling/test_tree/test_subset_tree_wrangler.py
+++ b/tests/test_data_wrangling/test_tree/test_subset_tree_wrangler.py
@@ -1,0 +1,37 @@
+"""Test the subset_tree_wrangler module."""
+from copy import deepcopy
+
+import numpy as np
+
+from lmpy.data_wrangling.tree.subset_tree_wrangler import SubsetTreeWrangler
+
+from tests.data_simulator import generate_tree
+
+
+# .....................................................................................
+def test_subset_tree_wrangler():
+    """Test subsetting a tree from taxa."""
+    all_species = [f'Species {i}' for i in range(100)]
+    # Shuffle and get taxa for tree
+    np.random.shuffle(all_species)
+    tree_species = all_species[:np.random.randint(51, 100)]
+    # Shuffle and get taxa for subsetting
+    np.random.shuffle(all_species)
+    subset_species = all_species[:np.random.randint(51, 100)]
+
+    # Generate a tree
+    tree = generate_tree(deepcopy(tree_species))
+
+    # Wrangle!
+    wrangler = SubsetTreeWrangler(subset_species)
+    wrangled_tree = wrangler.wrangle_tree(deepcopy(tree))
+
+    # Assert that we removed 0 to len(tree_species) - 1
+    report = wrangler.get_report()
+    assert report['purged'] >= 0
+    assert report['purged'] <= len(tree_species) - 1
+
+    # Assert that all taxa are in tree_species and subset_species
+    for taxon in wrangled_tree.taxon_namespace:
+        assert taxon.label in tree_species
+        assert taxon.label in subset_species


### PR DESCRIPTION
Add tree data wranglers for matching matrices and subsetting based on a taxon list

## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Add tree data wranglers for matching a matrix and a species list

## Link(s) to issue

#202 
