### PR TITLE
Pin pip version for read the docs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - coveralls
   - pytest
   - pytest-cov
-  - pip>=20.1
+  - pip=21.3.1
   - pip:
     - sphinx-rtd-theme
     - dendropy


### PR DESCRIPTION
Builds are currently failing and https://stackoverflow.com/questions/71410741/pip-uninstall-gdal-gives-attributeerror-pathmetadata-object-has-no-attribute suggests that downgrading pip may help

## Pull Request Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

This PR should address the build issues with read the docs

## Link(s) to issue

#180 

