### PR TITLE
Use encoding found within metadata of dwca

### DIFF
--- a/lmpy/point.py
+++ b/lmpy/point.py
@@ -611,7 +611,8 @@ class PointDwcaReader:
         # Read metadata
         # Get occurrence file ready
         self.file = io.TextIOWrapper(
-            self._zip_archive.open(self.occurrence_filename), encoding='utf8'
+            self._zip_archive.open(self.occurrence_filename),
+            encoding=self.occurrence_params['encoding']
         )
 
         delimiter = self.occurrence_params['fieldsTerminatedBy']


### PR DESCRIPTION
Use encoding value from meta.xml file rather than always assuming utf8

## Pull Request Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Use metadata for encoding for dwca files.

## Link(s) to issue

#142 

