### PR TITLE
Fix for intermittent test bug

### DIFF
--- a/tests/test_data_wrangling/test_occurrence/test_common_format_wrangler.py
+++ b/tests/test_data_wrangling/test_occurrence/test_common_format_wrangler.py
@@ -29,7 +29,7 @@ def test_common_format_instance():
             SimulatedField(
                 fld_name,
                 '',
-                get_random_float_func(0, 100, 3, 5),
+                get_random_float_func(1, 100, 3, 5),
                 'float'
             ) for fld_name in att_map.keys()
         ]


### PR DESCRIPTION
Testing the truth value of 0 is false so lower bound needs to be greater than that.

Currently has intermittent failures because value can be randomly chosen as zero

---
title: 'Pull request template'

---

## Pull Request Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

I am seeing some random failures in the tests because the value of an attribute is sometimes zero.  Increase the floor so that doesn't happen.  Failure is because bool of 0.0 is false.

