### PR TITLE
Fix for intermittent bug in common format

### DIFF
--- a/tests/test_data_wrangling/test_occurrence/test_common_format_wrangler.py
+++ b/tests/test_data_wrangling/test_occurrence/test_common_format_wrangler.py
@@ -75,7 +75,7 @@ def test_common_format_from_config():
             SimulatedField(
                 fld_name,
                 '',
-                get_random_float_func(0, 100, 3, 5),
+                get_random_float_func(1, 100, 3, 5),
                 'float'
             ) for fld_name in att_map.keys()
         ]


### PR DESCRIPTION
I fixed this in another place before.  The bug is with the test itself generating bad values, not the code processing them

---
title: 'Pull request template'

---

## Pull Request Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Fix bug in test that generates bad values.
