### PR TITLE
Suppress numpy warnings when encoding layers

### DIFF
--- a/lmpy/data_preparation/layer_encoder.py
+++ b/lmpy/data_preparation/layer_encoder.py
@@ -21,6 +21,9 @@ from osgeo import gdal, ogr
 from lmpy.matrix import Matrix
 from lmpy.spatial.geojsonify import geojsonify_matrix_with_shapefile
 
+
+# Suppress numpy warnings
+np.seterr(all='ignore')
 # DEFAULT_SCALE is the scale of the layer data array to the shapegrid cell size
 #     The number of data array cells in a (square) shapegrid cell is::
 #         1.0 / DEFAULT_SCALE^2


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Suppress numpy warnings for empty window slices when encoding layers

## Link(s) to issue

#271 
