### PR TITLE
Add capability to write out any updates to known name mapping

### DIFF
--- a/lmpy/data_wrangling/common/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/common/accepted_name_wrangler.py
@@ -40,7 +40,14 @@ def resolve_names_gbif(names, wait_time=.5):
 class _AcceptedNameWrangler(_DataWrangler):
     """Base class for accepted taxon name wranglers."""
     # .......................
-    def __init__(self, name_map=None, name_resolver=None):
+    def __init__(
+        self,
+        name_map=None,
+        name_resolver=None,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
+    ):
         """Constructor for the base accepted name wrangler.
 
         Args:
@@ -48,12 +55,31 @@ class _AcceptedNameWrangler(_DataWrangler):
             name_resolver (Method or None): If provided, this should be a function that
                 takes a list of names as input and returns a dictionary of name
                 mappings.  If omitted, resolving of new names will be skipped.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
         """
         if name_map is not None:
             self._load_name_map(name_map)
         else:
             self.name_map = {}
         self._name_resolver = name_resolver
+        self.out_name_map_filename = out_map_filename
+        self.map_write_interval = map_write_interval
+        self._updated_since_write = 0
+        self.out_map_format = out_map_format
+
+    # .......................
+    def __del__(self):
+        """Destructor method, sync map to disk if needed."""
+        if all(
+            [
+                self.out_name_map_filename is not None,
+                self._updated_since_write >= 0
+            ]
+        ):
+            self.write_map_to_file(self.out_name_map_filename, self.out_map_format)
 
     # .......................
     def _load_name_map(self, name_map):
@@ -103,6 +129,15 @@ class _AcceptedNameWrangler(_DataWrangler):
             # Update name map and return dictionary
             self.name_map.update(new_names)
             resolved_names.update(new_names)
+            self._updated_since_write += len(new_names.keys())
+            if all(
+                [
+                    self.out_name_map_filename is not None,
+                    self._updated_since_write >= self.map_write_interval
+                ]
+            ):
+                self.write_map_to_file(self.out_name_map_filename, self.out_map_format)
+                self._updated_since_write = 0
 
         return resolved_names
 

--- a/lmpy/data_wrangling/matrix/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/matrix/accepted_name_wrangler.py
@@ -21,6 +21,9 @@ class AcceptedNameMatrixWrangler(_MatrixDataWrangler, _AcceptedNameWrangler):
         name_resolver=None,
         taxon_axis=1,
         purge_failures=True,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
         **params
     ):
         """Constructor for AcceptedNameMatrixModifier class.
@@ -31,6 +34,10 @@ class AcceptedNameMatrixWrangler(_MatrixDataWrangler, _AcceptedNameWrangler):
                 accepted names.  If set to 'gbif', use GBIF name resolution.
             taxon_axis (int): The axis with taxon headers.
             purge_failures (bool): Should failures be purged from the matrix.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
             **params (dict): Keyword parameters to pass to _MatrixDataWrangler.
         """
         _MatrixDataWrangler.__init__(self, **params)
@@ -39,7 +46,10 @@ class AcceptedNameMatrixWrangler(_MatrixDataWrangler, _AcceptedNameWrangler):
         _AcceptedNameWrangler.__init__(
             self,
             name_map=name_map,
-            name_resolver=name_resolver
+            name_resolver=name_resolver,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
         )
 
         self.taxon_axis = taxon_axis

--- a/lmpy/data_wrangling/occurrence/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/occurrence/accepted_name_wrangler.py
@@ -18,16 +18,23 @@ class AcceptedNameOccurrenceWrangler(_OccurrenceDataWrangler, _AcceptedNameWrang
         name_map=None,
         name_resolver=None,
         store_original_attribute=None,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
         **params
     ):
         """Constructor for AcceptedNameModifier class.
 
         Args:
-            name_map (dict): A map of original name to accepted name.
+            name_map (dict or str): A map of original name to accepted name.
             name_resolver (str or Method): If provided, use this method for getting new
                 accepted names.  If set to 'gbif', use GBIF name resolution.
             store_original_attribute (str or None): A new attribute to store the
                 original taxon name.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
             **params (dict): Keyword parameters to pass to _OccurrenceDataWrangler.
         """
         _OccurrenceDataWrangler.__init__(self, **params)
@@ -37,7 +44,10 @@ class AcceptedNameOccurrenceWrangler(_OccurrenceDataWrangler, _AcceptedNameWrang
         _AcceptedNameWrangler.__init__(
             self,
             name_map=name_map,
-            name_resolver=name_resolver
+            name_resolver=name_resolver,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
         )
 
         self.store_original_attribute = store_original_attribute

--- a/lmpy/data_wrangling/tree/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/tree/accepted_name_wrangler.py
@@ -18,6 +18,9 @@ class AcceptedNameTreeWrangler(_TreeDataWrangler, _AcceptedNameWrangler):
         name_map=None,
         name_resolver=None,
         purge_failures=True,
+        out_map_filename=None,
+        map_write_interval=100,
+        out_map_format='json',
         **params
     ):
         """Constructor for AcceptedNameTreeModifier class.
@@ -27,6 +30,10 @@ class AcceptedNameTreeWrangler(_TreeDataWrangler, _AcceptedNameWrangler):
             name_resolver (str or Method): If provided, use this method for getting new
                 accepted names.  If set to 'gbif', use GBIF name resolution.
             purge_failures (bool): Should failures be purged from the tree.
+            out_map_filename (str): A file location to write the updated name map.
+            map_write_interval (int): Update the name map output file after each set of
+                this many iterations.
+            out_map_format (str): The format to write the names map (csv or json).
             **params (dict): Keyword parameters to pass to _TreeDataWrangler.
         """
         if isinstance(name_resolver, str) and name_resolver.lower() == 'gbif':
@@ -34,7 +41,10 @@ class AcceptedNameTreeWrangler(_TreeDataWrangler, _AcceptedNameWrangler):
         _AcceptedNameWrangler.__init__(
             self,
             name_map=name_map,
-            name_resolver=name_resolver
+            name_resolver=name_resolver,
+            out_map_filename=out_map_filename,
+            map_write_interval=map_write_interval,
+            out_map_format=out_map_format,
         )
         _TreeDataWrangler.__init__(self, **params)
 


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Can now write any updates to accepted name map from services like GBIF and Open Tree

## Link(s) to issue

#282 
