### PR TITLE
Add a mask parameter for generating stat heatmaps

### DIFF
--- a/lmpy/tools/create_stat_heatmap.py
+++ b/lmpy/tools/create_stat_heatmap.py
@@ -1,6 +1,8 @@
 """Create a stat heatmap image."""
 import argparse
 
+import numpy as np
+
 from lmpy.matrix import Matrix
 from lmpy.plots.map import create_stat_heatmap_matrix, plot_matrix
 from lmpy.tools._config_parser import _process_arguments
@@ -50,6 +52,11 @@ def build_parser():
         '--vmax',
         type=float,
         help='The maximum value for color scaling (use -1 to use maximum from data).'
+    )
+    parser.add_argument(
+        '--mask_matrix',
+        type=str,
+        help='File path to a binary matrix to use as a mask.'
     )
 
     parser.add_argument(
@@ -103,6 +110,12 @@ def cli():
     args = _process_arguments(parser, config_arg='config_file')
 
     matrix = Matrix.load(args.matrix_filename)
+    if args.mask_matrix is not None:
+        mask_matrix = Matrix.load(args.mask_matrix)
+        matrix = Matrix(
+            np.ma.masked_where(mask_matrix == 0, matrix),
+            headers=matrix.get_headers()
+        )
     matrix_heatmap = create_stat_heatmap_matrix(
         matrix,
         args.statistic,

--- a/tests/test_tools/test_create_stat_heatmap.py
+++ b/tests/test_tools/test_create_stat_heatmap.py
@@ -53,3 +53,63 @@ def test_create_stat_heatmap(monkeypatch, generate_temp_filename):
 
     monkeypatch.setattr('sys.argv', params)
     cli()
+
+
+# .....................................................................................
+def test_create_stat_heatmap_masked(monkeypatch, generate_temp_filename):
+    """Test the create_stat_heatmap cli tool with a mask on the matrix..
+
+    Args:
+        monkeypatch (pytest.Fixture): A pytest fixture for monkeypatching.
+        generate_temp_filename (pytest.fixture): Fixture to generate filenames.
+    """
+    plot_filename = generate_temp_filename(suffix='.png')
+    matrix_filename = generate_temp_filename(suffix='.lmm')
+    mask_matrix_filename = generate_temp_filename(suffix='.lmm')
+
+    min_x, min_y, max_x, max_y = (-180.0, -90.0, 180.0, 90.0)
+    resolution = .5
+
+    # Simulate some data
+    num_rows = 1000
+    stats = ['Stat_1', 'Stat_2', 'Stat_3']
+    matrix = Matrix(
+        np.random.randint(0, 100, size=(num_rows, len(stats))),
+        headers={
+            '0': [
+                (
+                    i,
+                    np.random.random() * (max_x - min_x) + min_x,
+                    np.random.random() * (max_y - min_y) + min_y
+                ) for i in range(num_rows)],
+            '1': stats
+        }
+    )
+    matrix.write(matrix_filename)
+    stat = matrix.get_column_headers()[1]
+
+    # Create mask matrix
+    mask_matrix = Matrix(
+        np.random.randint(0, 2, size=matrix.shape),
+        headers=matrix.get_headers()
+    )
+    mask_matrix.write(mask_matrix_filename)
+
+    params = [
+        'create_stat_heatmap.py',
+        '--title',
+        'Some plot title',
+        '--mask_matrix',
+        mask_matrix_filename,
+        plot_filename,
+        matrix_filename,
+        stat,
+        str(min_x),
+        str(min_y),
+        str(max_x),
+        str(max_y),
+        str(resolution),
+    ]
+
+    monkeypatch.setattr('sys.argv', params)
+    cli()


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Add a mask parameter to stat heatmap tool.  This would be used to mask a statistic to only visualize values deemed to be significant from hypothesis testing.

## Link(s) to issue

#304 
