### PR TITLE
317 extend data wrangler factory so that it can instantiate data wranglers not included with lmpy

### DIFF
--- a/lmpy/data_wrangling/factory.py
+++ b/lmpy/data_wrangling/factory.py
@@ -67,7 +67,15 @@ class WranglerFactory:
 
         wranglers = []
         for config in wrangler_configs:
-            wrangler = self.wrangler_types[config['wrangler_type']].from_config(config)
+            if 'module' in config.keys():
+                # If 'module' is specified, look in that module for the specified
+                #     data wrangler
+                m = importlib.import_module(config['module'])
+                wrangler = getattr(m, config['wrangler_type']).from_config(config)
+            else:
+                wrangler = self.wrangler_types[
+                    config['wrangler_type']
+                ].from_config(config)
             if wrangler.logger is None and self.default_logger is not None:
                 wrangler.logger = self.default_logger
             wranglers.append(wrangler)

--- a/tests/test_data_wrangling/test_factory.py
+++ b/tests/test_data_wrangling/test_factory.py
@@ -3,6 +3,11 @@ import json
 import os
 
 from lmpy.data_wrangling.factory import WranglerFactory
+from lmpy.data_wrangling.base import _DataWrangler
+from lmpy.data_wrangling.occurrence.base import _OccurrenceDataWrangler
+from lmpy.data_wrangling.occurrence.unique_localities_wrangler import (
+    UniqueLocalitiesFilter,
+)
 
 
 # ............................................................................
@@ -31,3 +36,22 @@ class Test_wrangler_factory:
             )
         wranglers = factory.get_wranglers(config)
         assert wranglers[0]
+
+
+# .....................................................................................
+def test_wrangler_from_config_with_module(generate_temp_filename):
+    """Test that we can get a data wrangler when specifying with a module.
+
+    Args:
+        generate_temp_filename (pytest.Fixture): A fixture for generating filenames.
+    """
+    wrangler_config = {
+        'module': 'lmpy.data_wrangling.occurrence.unique_localities_wrangler',
+        'wrangler_type': 'UniqueLocalitiesFilter'
+    }
+    factory = WranglerFactory()
+    wranglers = factory.get_wranglers([wrangler_config])
+    assert len(wranglers) == 1
+    assert isinstance(wranglers[0], _DataWrangler)
+    assert isinstance(wranglers[0], _OccurrenceDataWrangler)
+    assert isinstance(wranglers[0], UniqueLocalitiesFilter)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Add capability to specify a data wrangler outside of lmpy by using a 'module' attribute in configuration json.

## Link(s) to issue

#317 
