### PR TITLE
198 consider adding an option to perform multiple randomization runs with each call of randomize pam script

### DIFF
--- a/lmpy/tools/randomize_pam.py
+++ b/lmpy/tools/randomize_pam.py
@@ -1,5 +1,6 @@
 """This script will randomize a PAM while maintaining marginal totals."""
 import argparse
+from copy import deepcopy
 
 from lmpy import Matrix
 from lmpy.randomize.grady import grady_randomize
@@ -41,6 +42,7 @@ def build_parser():
     )
     parser.add_argument(
         'output_pam_filename',
+        nargs='+',
         type=str,
         help='The file location to write the randomized PAM.',
     )
@@ -53,8 +55,11 @@ def cli():
     parser = build_parser()
     args = _process_arguments(parser, config_arg='config_file')
     in_pam = Matrix.load(args.input_pam_filename)
-    rand_pam = randomize_pam(in_pam)
-    rand_pam.write(args.output_pam_filename)
+    if isinstance(args.output_pam_filename, str):
+        args.output_pam_filename = [args.output_pam_filename]
+    for out_fn in args.output_pam_filename:
+        rand_pam = randomize_pam(deepcopy(in_pam))
+        rand_pam.write(out_fn)
 
 
 # .....................................................................................

--- a/tests/test_tools/test_randomize_pam.py
+++ b/tests/test_tools/test_randomize_pam.py
@@ -65,6 +65,43 @@ def test_randomize(monkeypatch, observed_pam, generate_temp_filename):
 
 
 # .....................................................................................
+def test_randomize_multiple(monkeypatch, observed_pam, generate_temp_filename):
+    """Test that the randomize PAM tool works as expected with multiple outputs.
+
+    Args:
+        monkeypatch (pytest.Fixture): A pytest fixture for monkeypatching.
+        observed_pam (Matrix): A Presence-Absence Matrix for testing.
+        generate_temp_filename (pytest.fixture): Fixture to generate filenames.
+    """
+    # Get input marginal totals before randomization
+    row_totals = observed_pam.sum(axis=0)
+    col_totals = observed_pam.sum(axis=1)
+    total = observed_pam.sum()
+
+    obs_pam_filename = generate_temp_filename(suffix='.lmm')
+    rand_pam_filenames = [
+        generate_temp_filename(suffix='.lmm') for _ in range(np.random.randint(2, 10))
+    ]
+    # Write test PAM
+    observed_pam.save(obs_pam_filename)
+
+    # Run tool
+    params = ['randomize_pam.py', obs_pam_filename]
+    params.extend(rand_pam_filenames)
+    monkeypatch.setattr('sys.argv', params)
+    cli()
+
+    # Check output PAMs
+    for rand_pam_filename in rand_pam_filenames:
+        random_pam = Matrix.load(rand_pam_filename)
+
+        assert np.all(random_pam.sum(axis=0) == row_totals)
+        assert np.all(random_pam.sum(axis=1) == col_totals)
+        assert np.all(random_pam.sum() == total)
+        assert not np.all(random_pam != observed_pam)
+
+
+# .....................................................................................
 def test_randomize_config_file(monkeypatch, observed_pam, generate_temp_filename):
     """Test that the randomize PAM tool works as expected with a configuration file.
 
@@ -105,3 +142,49 @@ def test_randomize_config_file(monkeypatch, observed_pam, generate_temp_filename
     assert np.all(random_pam.sum(axis=1) == col_totals)
     assert np.all(random_pam.sum() == total)
     assert not np.all(random_pam != observed_pam)
+
+
+# .....................................................................................
+def test_randomize_config_file_many(monkeypatch, observed_pam, generate_temp_filename):
+    """Test that the randomize PAM tool works as expected with a configuration file.
+
+    Args:
+        monkeypatch (pytest.Fixture): A pytest fixture for monkeypatching.
+        observed_pam (Matrix): A Presence-Absence Matrix for testing.
+        generate_temp_filename (pytest.fixture): Fixture to generate filenames.
+    """
+    # Get input marginal totals before randomization
+    row_totals = observed_pam.sum(axis=0)
+    col_totals = observed_pam.sum(axis=1)
+    total = observed_pam.sum()
+
+    obs_pam_filename = generate_temp_filename(suffix='.lmm')
+    rand_pam_filenames = [
+        generate_temp_filename(suffix='.lmm') for _ in range(np.random.randint(2, 10))
+    ]
+    # Write test PAM
+    observed_pam.save(obs_pam_filename)
+
+    # Create configuration file
+    config_fn = generate_temp_filename(suffix='.json')
+    with open(config_fn, mode='wt') as config_out:
+        json.dump(
+            {
+                'input_pam_filename': obs_pam_filename,
+                'output_pam_filename': rand_pam_filenames,
+            },
+            config_out
+        )
+    # Run tool
+    params = ['randomize_pam.py', '--config_file', config_fn]
+    monkeypatch.setattr('sys.argv', params)
+    cli()
+
+    # Check output PAMs
+    for rand_pam_filename in rand_pam_filenames:
+        random_pam = Matrix.load(rand_pam_filename)
+
+        assert np.all(random_pam.sum(axis=0) == row_totals)
+        assert np.all(random_pam.sum(axis=1) == col_totals)
+        assert np.all(random_pam.sum() == total)
+        assert not np.all(random_pam != observed_pam)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Allow randomize pam tool to create multiple randomizations in a single call.

## Link(s) to issue

#198 

