### PR TITLE
Ensure at least one species will be removed from tree

### DIFF
--- a/tests/test_tools/test_wrangle_species_list.py
+++ b/tests/test_tools/test_wrangle_species_list.py
@@ -52,6 +52,7 @@ def test_wrangle_species_list(monkeypatch, generate_temp_filename):
     val_2 = np.random.randint(0, val_1)
     matrix_species = list(subset_pool)[:val_1]
     tree_species = list(subset_pool)[val_2:]
+    tree_species.append('Removethis species')  # Ensure 1+ will be removed
     common_species = set(matrix_species).intersection(set(tree_species))
 
     # Create matrix
@@ -184,6 +185,7 @@ def test_wrangle_species_list_script(script_runner, generate_temp_filename):
     val_2 = np.random.randint(0, val_1)
     matrix_species = list(subset_pool)[:val_1]
     tree_species = list(subset_pool)[val_2:]
+    tree_species.append('Removethis species')  # Ensure 1+ will be removed
     common_species = set(matrix_species).intersection(set(tree_species))
 
     # Create matrix


### PR DESCRIPTION
## Pull Request Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

Build tests were failing intermittently because the species pool sometimes overlapped enough where no species were removed from the tree.  Add an entry that will always be removed so that that test works properly.
