### PR TITLE
Idigbio fix

### DIFF
--- a/lmpy/data_wrangling/common/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/common/accepted_name_wrangler.py
@@ -8,7 +8,7 @@ from lmpy.data_wrangling.base import _DataWrangler
 
 
 # .....................................................................................
-def resolve_names_gbif(names, wait_time=.5):
+def resolve_names_gbif(names, wait_time=1):
     """Resolve names using GBIF's taxonomic name resolution service.
 
     Args:
@@ -19,13 +19,20 @@ def resolve_names_gbif(names, wait_time=.5):
     Returns:
         dict: Input names are keys and resolved name or None are values.
     """
+    attempt = 1
     resolved_names = {}
     for name_str in names:
         # Get name
         other_filters = {'name': name_str.strip(), 'verbose': 'true'}
         url = 'http://api.gbif.org/v1/species/match?{}'.format(
             urllib.parse.urlencode(other_filters))
-        response = requests.get(url).json()
+        try:
+            response = requests.get(url).json()
+        except Exception as err:
+            print(err)
+            print('Sleep and try again...')
+            time.sleep(60)
+            response = requests.get(url).json()
         if 'status' in response.keys() and response['status'].lower() in (
             'accepted',
             'synonym'

--- a/lmpy/data_wrangling/common/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/common/accepted_name_wrangler.py
@@ -89,7 +89,17 @@ class _AcceptedNameWrangler(_DataWrangler):
                 self._updated_since_write >= 0
             ]
         ):
-            self.write_map_to_file(self.out_name_map_filename, self.out_map_format)
+            try:
+                self.write_map_to_file(self.out_name_map_filename, self.out_map_format)
+            except Exception as err:
+                print(f'Failed to write names map on destruction: {err}.')
+                print(
+                    (
+                        'If this happened due to a crash, '
+                        'the "open" builtin may have already been removed.'
+                    )
+                )
+                raise err
 
     # .......................
     def _load_name_map(self, name_map):

--- a/lmpy/data_wrangling/common/accepted_name_wrangler.py
+++ b/lmpy/data_wrangling/common/accepted_name_wrangler.py
@@ -19,7 +19,6 @@ def resolve_names_gbif(names, wait_time=1):
     Returns:
         dict: Input names are keys and resolved name or None are values.
     """
-    attempt = 1
     resolved_names = {}
     for name_str in names:
         # Get name
@@ -82,7 +81,11 @@ class _AcceptedNameWrangler(_DataWrangler):
 
     # .......................
     def __del__(self):
-        """Destructor method, sync map to disk if needed."""
+        """Destructor method, sync map to disk if needed.
+
+        Raises:
+            Exception: Raised if writing name map fails.
+        """
         if all(
             [
                 self.out_name_map_filename is not None,
@@ -94,10 +97,8 @@ class _AcceptedNameWrangler(_DataWrangler):
             except Exception as err:
                 print(f'Failed to write names map on destruction: {err}.')
                 print(
-                    (
-                        'If this happened due to a crash, '
-                        'the "open" builtin may have already been removed.'
-                    )
+                    'If this happened due to a crash, '
+                    'the "open" builtin may have already been removed.'
                 )
                 raise err
 

--- a/lmpy/data_wrangling/occurrence/attribute_filter_wrangler.py
+++ b/lmpy/data_wrangling/occurrence/attribute_filter_wrangler.py
@@ -35,6 +35,8 @@ class AttributeFilterWrangler(_OccurrenceDataWrangler):
                     bad_values = filter_func['for-each']['values']
 
                     def _each_value_not_in(point):
+                        if point.get_attribute(self.attribute_name) is None:
+                            return True
                         return all(
                             [
                                 val not in bad_values

--- a/lmpy/point.py
+++ b/lmpy/point.py
@@ -537,6 +537,8 @@ class PointDwcaReader:
                 pass
             except StopIteration:
                 more_rows = False
+            except ValueError:
+                pass
             except csv.Error:
                 pass
 
@@ -560,6 +562,11 @@ class PointDwcaReader:
         # If core element is missing (iDigBio) look in extensions
         if core_element is None:
             self.is_idigbio = True
+            # Set spatial values for iDigBio if not provided
+            if self.geopoint_term is None:
+                self.geopoint_term = 'geoPoint'
+                self.x_term = 'lon'
+                self.y_term = 'lat'
             for extension_el in root_element.findall(EXTENSION_TAG):
                 if (
                         core_element is None


### PR DESCRIPTION
Fixes for iDigBio Darwin Core Archives

## Pull Request Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Description

This PR tells the PointDwcaReader to use the default iDigBio spatial fields (lat and lon inside of a geopoint field) if they are not provided and an iDigBio DarwinCore Archive is detected.  This is needed for scripts like split_occurrences that do not take those field name attributes to work properly.

Also add a message when writing out a name map on accepted name wrangler deletion fails because "open" has already been garbage collected by the interpreter.

Add a few other fail-safes that were needed with Hector's data and an often crashing (or at least throttling) GBIF names resolution service API.

